### PR TITLE
Dokumentation für MA10450 und TFA30.3312.02

### DIFF
--- a/MobileAlertsDevices.markdown
+++ b/MobileAlertsDevices.markdown
@@ -28,6 +28,7 @@ Here a list of all known products from Mobile Alerts. The product code is a mark
 | MA10320      | ID09 | Pro Thermo-hygro-sensor with ext. cable probe | –39.9°C…+59.9°C, ±1°C, cable probe –50°C…+110°C, ±0,5°C, 20%…99% ±5% | 3.5 min |
 | MA10350      | ID04 | Thermo-hygro-sensor with water detector | –39.9°C…+59.9°C, 20%…99%, ±4% | */7 min |
 | MA10410      | ID07 | Weather Station | indoor: -9.9°C…+59.9°C ±1°C, 20%…95% ±4%, outdoor -39.9°C…+59.9°C ±1°C, outdoor 1%…99% ±4% | 6 min |
+| MA10450      | ID0F | Weather Station | indoor: -9.9°C…+59.9°C ±1°C, outdoor -39.9°C…+59.9°C ±1°C | 7min |
 | MA10650      | ID08 | Rain meter | 0mm/h…300mm/h, 0.258mm | during rain up to every second, or every 2 hours during idle |
 | MA10660      | ID0B | Wind speed and wind direction display | wind and gusts: 0-50 m/s, ±5% or ±0.5 m/s, 0,02s gusts, direction 22,5° resolution | 6 min |
 | MA10700      | ID06 | Thermo-hygro-sensor with pool sensor | –39.9°C…+59.9°C ±1°C, 20%…99%, ±4% Pool:0°C…+59.9°C ±1°C | |

--- a/MobileAlertsDevices.markdown
+++ b/MobileAlertsDevices.markdown
@@ -35,7 +35,7 @@ Here a list of all known products from Mobile Alerts. The product code is a mark
 | MA10800      | ID10 | Contact sensor | | state change, or every 6 hours during idle |
 | MA10860      | ID0a | Sensor for acoustical observation of detectors | ? | ? |
 | WL2000       | ID05 | Air quality monitor | indoor: -9.5°C…+59.9°C ±1°C, 20%…95% ±4%, outdoor -39.9°C…+59.9°C ±1°C, outdoor 1%…99%, CO²-equivalent: 450ppm…3950ppm ±50ppm | 7 min |
-| ?            | ID0E | Thermo-hygro-sensor | | |
+| TFA30.3312.02 | ID0E | Thermo-hygro-sensor | –40.0°C…+60.0°C, 0.0%…99.0% | ? |
 | ?            | ID0F | Temperature sensor with ext. cable probe | | |
 | ?            | ID11 | 4 Thermo-hygro-sensors | | |
 

--- a/MobileAlertsGatewayBinaryUpload.markdown
+++ b/MobileAlertsGatewayBinaryUpload.markdown
@@ -32,6 +32,7 @@ Every 64-byte block has a simple 7-bit checksum. It is calculated by just summin
 |0xd3|ID10|0x17|open/close sensor|
 |0xd4|ID04|0x18|temperature + humidity + dry-contact|
 |0xd6|ID06|0x1a|temperature + humidity + pool temperature|
+|0xd8|ID0E|0x1c|temperature + humidity (with decimal place)|
 |0xd9|ID12|0x1d|humidity average + temperature + humidity |
 |0xda|ID07|0x1e|temperature in + humidity in + temperature out + humidity out|
 |0xe1|ID08|0x25|rain|
@@ -143,6 +144,16 @@ Starting here is the sensor depended data.
 | 0c | illegal sensor id |
 | 0d | illegal sensor id |
 | 0e | **Professional Thermo/Hygro sensor** |
+|    | 0 word: tx counter |
+|    | 2 word: temperature |
+|    | 4 word: humidity with decimal place |
+|    | 5 byte: unknown |
+|    | 7 word: previous temperature |
+|    | 9 word: previous humidity with decimal place |
+|    | 10 byte: unknown |
+|    | 11 word: previous temperature |
+|    | 13 word: previous humidity with decimal place |
+|    | 14 byte: unknown |
 | 0f | **Weather Station** |
 |    |  0 word: tx counter |
 |    |  2 word: temperature in |
@@ -208,6 +219,13 @@ A sensor error typically occurs if e.g. the water temperature sensor of the pool
 | 8…11  | unknown, typically a value of 10, on the MA10250PRO (Outdoor sensor) it is 0 |
 |   7   | unknown (MA10230 average values 1= "--" (not calculated)) |
 | 0…6   | humidity is a 7 bit value and read as % |
+
+#### Humidity with decimal place
+
+| Bits  | Meaning |
+|-------|---------|
+| 10-15 | unknown |
+| 0…9   | humidity is a 10 bit value in 1/10% |
 
 #### Wetness
 

--- a/MobileAlertsGatewayBinaryUpload.markdown
+++ b/MobileAlertsGatewayBinaryUpload.markdown
@@ -28,6 +28,7 @@ Every 64-byte block has a simple 7-bit checksum. It is calculated by just summin
 |----|----|----|-----------|
 |0xce|ID02|0x12|temperature|
 |0xd2|ID03|0x16|temperature + humidity|
+|0xd2|ID0F|0x16|temperature in + temperature out |
 |0xd3|ID10|0x17|open/close sensor|
 |0xd4|ID04|0x18|temperature + humidity + dry-contact|
 |0xd6|ID06|0x1a|temperature + humidity + pool temperature|
@@ -142,6 +143,12 @@ Starting here is the sensor depended data.
 | 0c | illegal sensor id |
 | 0d | illegal sensor id |
 | 0e | **Professional Thermo/Hygro sensor** |
+| 0f | **Weather Station** |
+|    |  0 word: tx counter |
+|    |  2 word: temperature in |
+|    |  4 word: temperature out |
+|    |  6 word: previous temperature in |
+|    |  8 word: previous temperature out |
 | 10 | **Door/Window sensor** (idle time: 6 hours) |
 |    |  0 word: tx counter |
 |    |  2 word: Bit 15: 0:Closed, 1:Open  |


### PR DESCRIPTION
Hallo,
ich habe die Daten von zwei neue Sensoren zu Gesicht bekommen und zwar aus dem FHEM-Forum. Einmal die Wetterstation MA10450 und der Thermo/Hydrosensor TFA30.3312.02. Anscheinend ist der TFA Weatherhub genau das gleiche wie Mobile Alerts (die APPs sind auf jeden Fall auch kompatibel).
Eine Nachricht für den MA10450 ist z.B. `d25a21c260160f0282f8d7a7009100c840c900c940cf2d0000000000000000000000000000000000000000000000000000000000000000000000000000000075 `.
Für den TFA30.3312.02: `d85a2188eb1c0e137a0f1242452e80ea83493400e783271e00e683041e0000000000000000000000000000000000000000000000000000000000000000000077`

Viele Grüße
Markus Feist