### PR TITLE
Make local IPv4 Adress be configurable in Config file

### DIFF
--- a/maserver/config-sample.json
+++ b/maserver/config-sample.json
@@ -8,5 +8,10 @@
 
   "proxyServerPort": 8080,
 
-  "mobileAlertsCloudForward": false
+  "mobileAlertsCloudForward": false,
+
+  "serverPost": null,
+  "serverPostUser": null,
+  "serverPostPassword": null
+
 }

--- a/maserver/config-sample.json
+++ b/maserver/config-sample.json
@@ -1,4 +1,5 @@
 {
+  "localIPv4Address": null,
   "mqtt": "mqtt://128.130.33.65",
   "mqtt_home": "MobileAlerts/",
 

--- a/maserver/gatewayConfig.js
+++ b/maserver/gatewayConfig.js
@@ -203,7 +203,7 @@ module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog) {
     }
   });
 
-  udpSocket.bind(function() {
+  udpSocket.bind({address: localIPv4Adress}, function() {
     udpSocket.setBroadcast(true);
 
     // after the bind delay the request by 250ms

--- a/maserver/mobilealerts.js
+++ b/maserver/mobilealerts.js
@@ -11,6 +11,10 @@ nconf.file({ file: 'config.json' });
 
 // Provide default values for settings not provided above.
 nconf.defaults({
+  // if set to null, then default IP address discovery will be used,
+  // otherwise use specified IP address
+  'localIPv4Address': null,
+
   'mqtt': 'mqtt://127.0.0.1',
   'mqtt_home': 'MobileAlerts/', // default MQTT path for the device parsed data
 
@@ -25,7 +29,13 @@ nconf.defaults({
   'mobileAlertsCloudForward': false,
 });
 
-const localIPv4Adress = require('./localIPv4Address')(1);
+var localIPv4Adress = "";
+if (nconf.get('localIPv4Address') == null) {
+  localIPv4Adress = require('./localIPv4Address')(1);
+} else {
+  localIPv4Adress = nconf.get('localIPv4Address');
+}
+
 console.log('### Local IP address for proxy: ' + localIPv4Adress);
 const proxyServerPort = nconf.get('proxyServerPort');
 


### PR DESCRIPTION
at my setup the automatic detection of the IP Adress fails. So I need to specify it by hand.
Adding the possibility to specify it in the config file.

My setup also has multiple IP ranges on the interface. If the gateway listens on a secondary network, it currently fails. Binding the udp socket to the ip adress the proxy is listening to, makes it work.