### PR TITLE
only add Authorization header if user and password are available

### DIFF
--- a/maserver/README.md
+++ b/maserver/README.md
@@ -1,7 +1,21 @@
 # maserver
 
-This simple node example server uses UDP to find a Mobile Alerts Gateway in the local network and modifies it's proxy server settings to point to the machine running the node server. The node server also provides a HTTP proxy to intercept all packages from the gateway, decodes them and forwards them to a MQTT server.
+This simple node example server uses UDP to find a Mobile Alerts Gateway in the local network and modifies it's proxy server settings to point to the machine running the node server. The node server also provides a HTTP proxy to intercept all packages from the gateway, decodes them and forwards them to a MQTT server, a HTTP(S) JSON REST Server or the Mobile Alerts Cloud.
 
 Run ```npm install``` in this directory to install all dependencies and then run ```mobilealerts.js```.
 
-A ```config.json``` can contain the configuration for the MQTT server. You might also have to update the ```localIPv4Address.js``` to match the machine, depending on which OS you are running the node server.
+A ```config.json``` can contain the configuration for the MQTT server, the HTTP(S) JSON REST Server or enable the Mobile Alerts Cloud. If the automatic IPv4 address detection does not work, you can specify the IPv4 address in the config.json file.
+
+Just copy the ```config-sample.json``` file to ```config.json``` and update the values.
+
+Hints for the ```config.json``` keys:
+  * **localIPv4Address:** if set to null, then default IP address discovery will be used, otherwise use specified IP address
+  * **mqtt:** specify the address of the mqtt Server in the form ```mqtt://127.0.0.1```
+  * **mqtt_home:** default MQTT path for the device parsed data
+  * **logfile:** if specified, all packages will be logged in a logfile as a whole for future debugging
+  * **logGatewayInfo:** display info about all found gateways
+  * **proxyServerPort:** TCP port where the proxy is listening for incoming connections
+  * **mobileAlertsCloudForward:** set to ```true``` if you want to forward the packages to the mobile alerts cloud
+  * **serverPost:** set to the POST URL where the JSON data should be sent to
+  * **serverPostUser**, **serverPostPassword**: Basic Authorization user and password for the POST URL
+

--- a/maserver/config-sample.json
+++ b/maserver/config-sample.json
@@ -1,6 +1,6 @@
 {
   "localIPv4Address": null,
-  "mqtt": "mqtt://128.130.33.65",
+  "mqtt": "mqtt://127.0.0.1",
   "mqtt_home": "MobileAlerts/",
 
   "logfile": "./MobileAlerts.log",

--- a/maserver/mobilealerts.js
+++ b/maserver/mobilealerts.js
@@ -134,10 +134,9 @@ function sendPOST(sensor) {
   var auth = "";
   var header = {};
   if (nconf.get('serverPostUser') != null && nconf.get('serverPostPassword') != null) {
-    var auth = 'Basic ' + Buffer.from(nconf.get('serverPostUser') + ':' + nconf.get('serverPostPassword')).toString('base64');
+    auth = 'Basic ' + Buffer.from(nconf.get('serverPostUser') + ':' + nconf.get('serverPostPassword')).toString('base64');
+    header = {'Authorization': auth};
   }
-
-  header = {'Authorization': auth};
 
   var options = {
     uri: serverPost,


### PR DESCRIPTION
I wanted to create a new pull request for the HTTP JSON Post but github seems to have taken it with the other stuff.

I found a little issue that I set an auth header even if no auth is wanted.
Fixed now.

Additionally I updated the README file to update the new capabilities.
I also described the config parameters.