### PR TITLE
Dokumentation for TFA30.3060.01 and MA10120PRO

### DIFF
--- a/MobileAlertsDevices.markdown
+++ b/MobileAlertsDevices.markdown
@@ -17,7 +17,7 @@ Here a list of all known products from Mobile Alerts. The product code is a mark
 | Product code | ID   | Device name      | Accuracy | Transmission Rate |
 |--------------|------|------------------|----------|-------------------|
 | MA10000      | ID00 | Gateway          |          | |
-| ?            | ID01 | Temperature sensor with ext. cable probe | | |
+| MA10120      | ID01 | Pro Temperature sensor with ext. cable probe | -29,9…+59,9 °C, ±1°C | 7 min |
 | MA10100      | ID02 | Temperature sensor | -29.9°C…+59.9°C, ±1°C | 7 min |
 | MA10101      | ID02 | Temperature sensor with cable probe | –29.9°C…+59.9°C | 7 min |
 | MA10120      | ID09 | Pro Temperature sensor with cable probe | –29.9°C…+59.9°C ±1°C | 7 min |
@@ -37,7 +37,7 @@ Here a list of all known products from Mobile Alerts. The product code is a mark
 | WL2000       | ID05 | Air quality monitor | indoor: -9.5°C…+59.9°C ±1°C, 20%…95% ±4%, outdoor -39.9°C…+59.9°C ±1°C, outdoor 1%…99%, CO²-equivalent: 450ppm…3950ppm ±50ppm | 7 min |
 | TFA30.3312.02 | ID0E | Thermo-hygro-sensor | –40.0°C…+60.0°C, 0.0%…99.0% | ? |
 | ?            | ID0F | Temperature sensor with ext. cable probe | | |
-| ?            | ID11 | 4 Thermo-hygro-sensors | | |
+| TFA30.3060.01 | ID11 | 4 Thermo-hygro-sensors | indoor: -10°C…+60°C ±1°C, outdoor -40°C…+60°C ±1°C, 1%…99% ±3% | |
 
 Each device has a unique device ID, which is 12 uppercase characters long. Every device within the range of the gateway is received by the gateway and forwarded to the internet, it technically is not necessary to know the ID, you can find it out by listening to the gateway.
 

--- a/MobileAlertsGatewayBinaryUpload.markdown
+++ b/MobileAlertsGatewayBinaryUpload.markdown
@@ -27,6 +27,7 @@ Every 64-byte block has a simple 7-bit checksum. It is calculated by just summin
 | header | device ID | package length | sensor type |
 |----|----|----|-----------|
 |0xce|ID02|0x12|temperature|
+|0xd2|ID01|0x16|teperature in + temperature cable |
 |0xd2|ID03|0x16|temperature + humidity|
 |0xd2|ID0F|0x16|temperature in + temperature out |
 |0xd3|ID10|0x17|open/close sensor|
@@ -38,6 +39,7 @@ Every 64-byte block has a simple 7-bit checksum. It is calculated by just summin
 |0xda|ID07|0x1e|temperature in + humidity in + temperature out + humidity out|
 |0xe1|ID08|0x25|rain|
 |0xe2|ID0b|0x26|wind|
+|0xea|ID11|0x2e|4 times temperature and humidity |
 
 ### Offset 1: UNIX UTC Timestamp
 A 4 byte UNIX UTC timestamp when the data was received by the gateway.
@@ -53,6 +55,12 @@ Starting here is the sensor depended data.
 
 | ID | Format of data |
 |----|----------------|
+| 01 | **Temperature sensor in/cable** |
+|    |  0 word: tx counter |
+|    |  2 word: current temperature |
+|    |  4 word: current temperature cable |
+|    |  6 word: previous temperature |
+|    |  8 word: previous temperature cable |
 | 02 | **Temperature sensor** |
 |    |  0 word: tx counter |
 |    |  2 word: current temperature |
@@ -180,6 +188,24 @@ Starting here is the sensor depended data.
 |    |  4 word: previous state (lower 12 bits contain the time in seconds/minutes/hours/days since last event) |
 |    |  6 word: previous state |
 |    |  8 word: previous state |
+| 11 | **4 Thermo-hygro-sensors (TFA30.3060.01)** |
+|    |  0 word: tx counter |
+|    |  2 word: temperature sensor 1 |
+|    |  4 word: humidity sensor 1 |
+|    |  6 word: temperature sensor 2 |
+|    |  8 word: humidity sensor 2 |
+|    |  10 word: temperature sensor 3 |
+|    |  12 word: humidity sensor 3 |
+|    |  14 word: temperature in |
+|    |  16 word: humidity in |
+|    |  18 word: previous temperature sensor 1 |
+|    |  20 word: previous humidity sensor 1 |
+|    |  22 word: previous temperature sensor 2 |
+|    |  24 word: previous humidity sensor 2 |
+|    |  26 word: previous temperature sensor 3 |
+|    |  28 word: previous humidity sensor 3 |
+|    |  30 word: previous temperature in |
+|    |  32 word: previous humidity in |
 | 12 | **Humidity Guard (MA10230)** |
 |    |  0 word: tx counter |
 |    |  2 byte: 3h humidity average |


### PR DESCRIPTION
Hallo,
ich habe wieder eine Dokumentationsergänzung für die Sensoren TFA30.3060.01 und MA10120PRO.
Der TFA ist eine Basisstation mit drei Sensoren. Eine Beispielnachricht ist diese hier:
`ea5b77c3a72e1135b8017d8712fb00ee083c00bc085100c7084b00eb083c00ee083c00bc085100c7084b00eb083c1b000000000000000000000000000000001f`
Die Werte waren:
`ID: 1135B8017D87`
`Zeitpunkt: 18.08.2018 08:58:47`
`Temp In: 23,5 C`
`Hum In: 60%`
`Temp 1: 23,8 C`
`Hum 1: 60%`
`Temp 2: 18,8 C`
`Hum 2: 81%`
`Temp 3: 19,9 C`
`Hum 3: 75%`

Der MA10120PRO ist ein Temperatursensor mit einem zusätzlichen Kabelsensor.
`d25b784fe8160104b30513ee000241058f23811627ff1bc01228d3b0142bd3c00e32d3c01735d300000000000000000000000000000000000000000000000043`
Die Werte waren:
`Temp In: 26,1`
`Temp Out: -22,1`
Die Extremwerte rühren daher, dass der Anwender den Temperatursensor am Kabel gegen einen Fotowiderstand getauscht hat (auf jeden Fall ein interessanter Anwendungsfall).

Was ich jetzt allerdings noch seltsam finde. In der Doku (MobileAlertsDevices.markdown) steht:
| MA10120      | ID09 | Pro Temperature sensor with cable probe | –29.9°C…+59.9°C ±1°C | 7 min |
Allerdings der MA10120, von dem ich die Nachricht habe, hat die ID01.
Die ID09 ist außerdem auch beim MA10320 belegt. Für den 10320 habe ich die ID09 auch schon als Nachricht gesehen.
Kann es sein, dass diese Zeile falsch ist und raus müsste?

Viele Grüße
Markus

