### PR TITLE
Support Docker

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:lts-alpine
+COPY ../maserver /maserver
+RUN apk update &&\
+    apk upgrade &&\
+    apk add --no-cache bash &&\
+    npm install /maserver
+
+ENTRYPOINT node /maserver/mobilealerts.js
+WORKDIR /maserver
+

--- a/Docker/buildImage.sh
+++ b/Docker/buildImage.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t mobilealerts .

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.1'
+
+volumes:
+  mobilealerts_conf:
+  node_red_data:
+    external: true
+
+networks:
+  node-red-net:
+
+services:
+  nodered:
+    container_name: node-red
+    image: nodered/node-red:latest
+    environment:
+      - TZ=Europe/Berlin
+    ports:
+      - 1880:1880
+      - 1883:1883
+    networks:
+      - node-red-net
+    restart: always
+    volumes:
+      - node_red_data:/data
+  ma:
+    container_name: mobilealerts
+    image: mobilealerts
+    environment:
+      - TZ=Europe/Berlin
+    ports:
+      - 8888:8888
+    networks:
+      - node-red-net
+    volumes:
+      - mobilealerts_conf:/maserver/conf
+

--- a/maserver/config-sample.json
+++ b/maserver/config-sample.json
@@ -2,7 +2,8 @@
   "localIPv4Address": null,
   "mqtt": "mqtt://127.0.0.1",
   "mqtt_home": "MobileAlerts/",
-
+  "mqtt_username": "user",
+  "mqtt_password": "password",
   "logfile": "./MobileAlerts.log",
   "logGatewayInfo": true,
 

--- a/maserver/gatewayConfig.js
+++ b/maserver/gatewayConfig.js
@@ -4,7 +4,7 @@
 // so that all requests are send to us instead into the cloud.
 // After the configuration this module is no longer needed and closes itself.
 
-module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog,gatewayIP) {
+module.exports = function(localIPv4Adress,proxyIPv4Address,proxyServerPort,gatewayID,debugLog,gatewayIP) {
   if(!debugLog) debugLog = true;
   // a port of 0 disables the proxy server
   const proxyServerActiveFlag = proxyServerPort != 0;
@@ -136,7 +136,7 @@ module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog,gat
         // update proxy settings, if they are different from the expected ones
         if(currentProxyServerActiveFlag != proxyServerActiveFlag
            || currentProxyServerPort != proxyServerPort
-           || currentProxyServerName != localIPv4Adress) {
+           || currentProxyServerName != proxyIPv4Address) {
           console.log('### Update Mobile Alerts Gateway Proxy Settings');
 
           // build a set config buffer by copying everything out of the get config
@@ -177,7 +177,7 @@ module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog,gat
           // erase Proxy Server Name
           sendConfigBuffer.fill(0, 0x6e, 0xaf);
           // copy new proxy server name
-          sendConfigBuffer.write(localIPv4Adress, 0x6e, 'utf-8');
+          sendConfigBuffer.write(proxyIPv4Address, 0x6e, 'utf-8');
           // Proxy Port
           sendConfigBuffer.writeInt16BE(proxyServerPort, 0xaf);
 

--- a/maserver/gatewayConfig.js
+++ b/maserver/gatewayConfig.js
@@ -4,7 +4,7 @@
 // so that all requests are send to us instead into the cloud.
 // After the configuration this module is no longer needed and closes itself.
 
-module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog) {
+module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog,gatewayIP) {
   if(!debugLog) debugLog = true;
   // a port of 0 disables the proxy server
   const proxyServerActiveFlag = proxyServerPort != 0;
@@ -14,9 +14,8 @@ module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog) {
   // This is the UDP port used by the Mobile Alerts Gateway
   // for the configuration
   const PORT = 8003;
-  // all communication with the gateways are broadcasts
-  const BROADCAST_ADDR = '255.255.255.255';
-
+  //If gatewayIP parameter is set take it, else fallback to broadcast address
+  const GATEWAY_ADDR = gatewayIP ? gatewayIP : '255.255.255.255';
   // Find any available gateway in the local network
   const FIND_GATEWAYS = 1
   // Find a single available gateway in the local network
@@ -182,7 +181,7 @@ module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog) {
           // Proxy Port
           sendConfigBuffer.writeInt16BE(proxyServerPort, 0xaf);
 
-          udpSocket.send(sendConfigBuffer, PORT, BROADCAST_ADDR, function() {
+          udpSocket.send(sendConfigBuffer, PORT, GATEWAY_ADDR, function() {
 
             // reboot the gateway after a reconfig
             var rebootGatewayCommand = new Buffer(REBOOT_SIZE);
@@ -192,7 +191,7 @@ module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog) {
             message.copy(rebootGatewayCommand, 0x02, 0x02, 0x08);
             rebootGatewayCommand.writeInt16BE(REBOOT_SIZE, 0x08);
 
-            udpSocket.send(rebootGatewayCommand, PORT, BROADCAST_ADDR, function() {
+            udpSocket.send(rebootGatewayCommand, PORT, GATEWAY_ADDR, function() {
               udpSocket.close();
             });
           });
@@ -213,7 +212,7 @@ module.exports = function(localIPv4Adress,proxyServerPort,gatewayID,debugLog) {
       findGatewayCommand.fill(0, 0x00, FIND_GATEWAYS_SIZE);
       findGatewayCommand.writeInt16BE(FIND_GATEWAYS, 0x00);
       findGatewayCommand.writeInt16BE(FIND_GATEWAYS_SIZE, 0x08);
-      udpSocket.send(findGatewayCommand, PORT, BROADCAST_ADDR, function() {});
+      udpSocket.send(findGatewayCommand, PORT, GATEWAY_ADDR, function() {});
     }, 250);
   });
 

--- a/maserver/mobilealerts.js
+++ b/maserver/mobilealerts.js
@@ -227,8 +227,13 @@ function processSensorData(buffer) {
 // #############################################################
 
 // configure the Mobile Alerts Gateway to use us as a proxy server, if necessary
+const publicIPv4Adress = nconf.get('publicIPv4adress')
+//In case NAT is used configuration can contain public IP -> Could contain docker system public IP
+const proxyListenIp = publicIPv4Adress ? publicIPv4Adress : localIPv4Adress;
+
 const gatewayConfigUDP = require('./gatewayConfig')(
                           localIPv4Adress
+                        , proxyListenIp
                         , proxyServerPort
                         , nconf.get('gatewayID')
                         , nconf.get('logGatewayInfo')

--- a/maserver/mobilealerts.js
+++ b/maserver/mobilealerts.js
@@ -9,6 +9,8 @@ nconf.argv().env();
 
 // Then load configuration from a designated file.
 nconf.file({ file: 'config.json' });
+// If configuration under conf exist -> load it this helps when running in docker and docker volume for conf is mounted under conf
+nconf.file({ file: 'conf/config.json' });
 
 // Provide default values for settings not provided above.
 nconf.defaults({

--- a/maserver/mobilealerts.js
+++ b/maserver/mobilealerts.js
@@ -231,7 +231,8 @@ const gatewayConfigUDP = require('./gatewayConfig')(
                           localIPv4Adress
                         , proxyServerPort
                         , nconf.get('gatewayID')
-                        , nconf.get('logGatewayInfo'));
+                        , nconf.get('logGatewayInfo')
+                        , nconf.get('gatewayIp'));
 
 // setup ourselves as a proxy server for the Mobile Alerts Gateway.
 // All 64-byte packages will arrive via this function


### PR DESCRIPTION
I wanted to run you tool in a docker environment.
This has some implications:
- Broadcasts are not working as the container is in a virtual network
- The detected local IP address can't be reached by the mobile alert gateway

I've added two new configuration parameters:
- proxyIPv4Adress - IP that is configured as the proxy address in the weather station (in docker scenario IP of the docker host system)
- gatewayIp - the manually defined IP address of the weather station because broadcast isn't working in docker environment

If the parameters are not set everything should behave as before.
In the new Docker directory in the repo there is a Dockerfile that can be used to build an image (just execute buildImage.sh) and an example docker-compose.yml that builds a docker compose stack of two containers (node-red and mobilealerts) together. Node red could be used to start a MQTT broker and receive data from mobilealerts.