### PR TITLE
Added documentation for MA10238 and MA10880

### DIFF
--- a/MobileAlertsDevices.markdown
+++ b/MobileAlertsDevices.markdown
@@ -23,6 +23,7 @@ Here a list of all known products from Mobile Alerts. The product code is a mark
 | MA10120      | ID09 | Pro Temperature sensor with cable probe | –29.9°C…+59.9°C ±1°C | 7 min |
 | MA10200      | ID03 | Thermo-hygro-sensor | –39.9°C…+59.9°C, 20%…99%, ±4% | 7 min |
 | MA10230      | ID12 | Indoor Climate Status | –39.9°C…+59.9°C, ±0.8°C, 1%…99%, ±3% | |
+| MA10238      | ID18 | Air pressure monitor | -9,9…+59,9°C, ± 1°C, 1…99 % ± 5 %, 700…1150 mbar | 6 min |
 | MA10250      | ID03 | Thermo-Hygro Outdoor | –39.9°C…+59.9°C, ±1°C, 20%…99% ±5% | 7 min |
 | MA10300      | ID03 | Thermo-hygro-sensor with cable probe | –39.9°C…+59.9°C, 20%…99%, ±4% | 7 min |
 | MA10320      | ID09 | Pro Thermo-hygro-sensor with ext. cable probe | –39.9°C…+59.9°C, ±1°C, cable probe –50°C…+110°C, ±0,5°C, 20%…99% ±5% | 3.5 min |

--- a/MobileAlertsDevices.markdown
+++ b/MobileAlertsDevices.markdown
@@ -34,6 +34,7 @@ Here a list of all known products from Mobile Alerts. The product code is a mark
 | MA10700      | ID06 | Thermo-hygro-sensor with pool sensor | –39.9°C…+59.9°C ±1°C, 20%…99%, ±4% Pool:0°C…+59.9°C ±1°C | |
 | MA10800      | ID10 | Contact sensor | | state change, or every 6 hours during idle |
 | MA10860      | ID0a | Sensor for acoustical observation of detectors | ? | ? |
+| MA10880      | ID15 | 4 button switch | ? | ? |
 | MA10900      | ID07 | Color Display Weather Station | indoor: -9.9°C…+59.9°C ±1°C, 1%…99% ±4%, outdoor -39.9°C…+59.9°C ±1°C, outdoor 1%…99% ±4% | 7 min |
 | WL2000       | ID05 | Air quality monitor | indoor: -9.5°C…+59.9°C ±1°C, 20%…95% ±4%, outdoor -39.9°C…+59.9°C ±1°C, outdoor 1%…99%, CO²-equivalent: 450ppm…3950ppm ±50ppm | 7 min |
 | TFA30.3312.02 | ID0E | Thermo-hygro-sensor | –40.0°C…+60.0°C, 0.0%…99.0% | ? |

--- a/MobileAlertsGatewayBinaryUpload.markdown
+++ b/MobileAlertsGatewayBinaryUpload.markdown
@@ -27,6 +27,7 @@ Every 64-byte block has a simple 7-bit checksum. It is calculated by just summin
 | header | device ID | package length | sensor type |
 |----|----|----|-----------|
 |0xce|ID02|0x12|temperature|
+|0xce|ID15|0x12|4 button switch|
 |0xd2|ID01|0x16|teperature in + temperature cable |
 |0xd2|ID03|0x16|temperature + humidity|
 |0xd2|ID0F|0x16|temperature in + temperature out |
@@ -215,6 +216,11 @@ Starting here is the sensor depended data.
 |    |  6 word: current temperature |
 |    |  8 byte: current humidity |
 |    |  9-16: unknown (pervious values?) |
+| 15 | **4 button switch (MA10880)** |
+|    |  0 word: tx counter |
+|    |  1 byte: button state |
+|    |          Bit 7-4: number of button (0001=green, 0010=orange, 0011=red, 0100=yellow)
+|    |          Bit 3-0: info for pressed button (0001=short, 0002=2 times short, 0003=long)
 
 ### Value decoding
 

--- a/MobileAlertsGatewayBinaryUpload.markdown
+++ b/MobileAlertsGatewayBinaryUpload.markdown
@@ -26,6 +26,7 @@ Every 64-byte block has a simple 7-bit checksum. It is calculated by just summin
 ### Offset 0: Package Header
 | header | device ID | package length | sensor type |
 |----|----|----|-----------|
+|0xcb|ID0a|0x0f|Sensor for acoustical observation of detectors |
 |0xce|ID02|0x12|temperature|
 |0xce|ID15|0x12|4 button switch|
 |0xd2|ID01|0x16|teperature in + temperature cable |

--- a/MobileAlertsGatewayBinaryUpload.markdown
+++ b/MobileAlertsGatewayBinaryUpload.markdown
@@ -35,10 +35,12 @@ Every 64-byte block has a simple 7-bit checksum. It is calculated by just summin
 |0xd3|ID10|0x17|open/close sensor|
 |0xd4|ID04|0x18|temperature + humidity + dry-contact|
 |0xd6|ID06|0x1a|temperature + humidity + pool temperature|
+|0xd6|ID09|0x1a|temperature + humidity + temperature cable|
 |0xd8|ID0E|0x1c|temperature + humidity (with decimal place)|
 |0xd9|ID12|0x1d|humidity average + temperature + humidity |
 |0xda|ID05|0x1e|temperature out + tempereature in + humidity + air quality |
 |0xda|ID07|0x1e|temperature in + humidity in + temperature out + humidity out|
+|0xe0|ID18|0x24|air pressure monitor|
 |0xe1|ID08|0x25|rain|
 |0xe2|ID0b|0x26|wind|
 |0xea|ID11|0x2e|4 times temperature and humidity |
@@ -222,6 +224,11 @@ Starting here is the sensor depended data.
 |    |  1 byte: button state |
 |    |          Bit 7-4: number of button (0001=green, 0010=orange, 0011=red, 0100=yellow)
 |    |          Bit 3-0: info for pressed button (0001=short, 0002=2 times short, 0003=long)
+| 18 | **air pressure monitor (MA10238)** |
+|    |  0 word + byte: 3-byte tx counter |
+|    |  3 word: temperature |
+|    |  5 byte: humidity |
+|    |  6 word: air pressure |
 
 ### Value decoding
 


### PR DESCRIPTION
Hallo,
nach längerer Zeit bin ich durch eigene Verwendung und das FHEM Forum wieder an Messages für weitere Geräte gekommen und jetzt auch dazu gekommen die Dokumentation anzupassen.
Einmal ist es der Luftdruckmonitor MA10238 und der Schalter MA10880. Zusätzlich habe ich beim Abgleich mit den bei mir im FHEM-Modul inzwischen vorhandenen Geräten noch zwei fehlende Einträge in der "Package-Header" Tabelle gefunden.

Viele Grüße
Markus