### PR TITLE
Fix: replace request-micro with dropin-request in maserver

### DIFF
--- a/maserver/gatewayProxyServer.js
+++ b/maserver/gatewayProxyServer.js
@@ -11,7 +11,7 @@ module.exports = function(localIPv4Adress,proxyServerPort
   const bodyParser = require('body-parser');
   const getRawBody = require('raw-body');
   const fs = require('fs');
-  const request = require('request-micro');
+  const request = require('dropin-request');
 
   const app = express();
   app.use(bodyParser.urlencoded({ extended: false }));

--- a/maserver/mobilealerts.js
+++ b/maserver/mobilealerts.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
-const request = require('request-micro');
+const request = require('dropin-request');
 const easyConf = require('./easyConf');
 const eConf = new easyConf();
 

--- a/maserver/package.json
+++ b/maserver/package.json
@@ -9,7 +9,7 @@
     "express": "*",
     "body-parser": "*",
     "raw-body": "*",
-    "request": "*",
+    "dropin-request": "*",
     "lodash": "*"
   }
 }


### PR DESCRIPTION
Hi @sarnau,
I've noticed that request-micro is causing issues and it is not working reliably in the maserver component on my end. Problems appear when using cloud forwarding  (as 'request-micro' is only used in that scenario). I've found 'dropin-request' working fine without any additional code changes.
Changes:

    Replaced request-micro with dropin-request (which provides the same API but is more stable/maintained).
    Updated package.json accordingly.
    Updated require statements in the source code.

This should fix the request issues while keeping the existing logic intact.
Best regards