### PR TITLE
include battery flag of sub-sensors of ID11

### DIFF
--- a/MobileAlertsGatewayBinaryUpload.markdown
+++ b/MobileAlertsGatewayBinaryUpload.markdown
@@ -256,7 +256,7 @@ Starting here is the sensor depended data.
 |  14   | unknown, typically 0, but can be 1 |
 |  13   | overflow (too hot for the sensor) and is displayed as "OFL°C" |
 |  12   | sensor error occurred. It is represented as "---°C" |
-|  11   | unknown, always seems to be 0. |
+|  11   | battery low flag: 0 if battery ok, 1 if low, relevant for sub-sensors of WeatherStation (ID11). |
 | 0…10  | temperature is a signed 11 bit value in 1/10°C.
 |       | 0…1023 represents 0.0°C…102.3°C = value * 0.1 |
 |       | 1024…2047 do represent -102.4°C…-0.1°C = (2048-value) * -0.1 |

--- a/maserver/sensors.js
+++ b/maserver/sensors.js
@@ -566,15 +566,29 @@ Sensor_ID11.prototype.transmitInterval = function () {
 }
 Sensor_ID11.prototype.generateJSON = function (buffer) {
 
+    // read current temperature values separately in order to detect battery flag
+    const rawTemp1 = buffer.readUInt16BE(0);
+    const rawTemp2 = buffer.readUInt16BE(4);
+    const rawTemp3 = buffer.readUInt16BE(8);
+
+    // check bit 11 for battery status
+    const bat1Status = ((rawTemp1 & 0x0800) === 0x0800) ? 'low' : 'ok';
+    const bat2Status = ((rawTemp2 & 0x0800) === 0x0800) ? 'low' : 'ok';
+    const bat3Status = ((rawTemp3 & 0x0800) === 0x0800) ? 'low' : 'ok';
+
     return {
-        'temperature1': [this.convertTemperature(buffer.readUInt16BE(0)), this.convertTemperature(buffer.readUInt16BE(16))],
+        'temperature1': [this.convertTemperature(rawTemp1), this.convertTemperature(buffer.readUInt16BE(16))],
         'humidity1': [this.convertHumidity(buffer.readUInt16BE(2)), this.convertHumidity(buffer.readUInt16BE(18))],
-        'temperature2': [this.convertTemperature(buffer.readUInt16BE(4)), this.convertTemperature(buffer.readUInt16BE(20))],
+        'temperature2': [this.convertTemperature(rawTemp2), this.convertTemperature(buffer.readUInt16BE(20))],
         'humidity2': [this.convertHumidity(buffer.readUInt16BE(6)), this.convertHumidity(buffer.readUInt16BE(22))],
-        'temperature3': [this.convertTemperature(buffer.readUInt16BE(8)), this.convertTemperature(buffer.readUInt16BE(24))],
+        'temperature3': [this.convertTemperature(rawTemp3), this.convertTemperature(buffer.readUInt16BE(24))],
         'humidity3': [this.convertHumidity(buffer.readUInt16BE(10)), this.convertHumidity(buffer.readUInt16BE(26))],
         'temperatureIN': [this.convertTemperature(buffer.readUInt16BE(12)), this.convertTemperature(buffer.readUInt16BE(28))],
-        'humidityIN': [this.convertHumidity(buffer.readUInt16BE(14)), this.convertHumidity(buffer.readUInt16BE(30))]
+        'humidityIN': [this.convertHumidity(buffer.readUInt16BE(14)), this.convertHumidity(buffer.readUInt16BE(30))],
+        
+        'battery1': bat1Status,
+        'battery2': bat2Status,
+        'battery3': bat3Status
     };
 }
 


### PR DESCRIPTION
Sensors connected to WeatherStation (ID11) do report their battery status encoded in current temperature (bit 11). Evaluate it and include it into json response. Also update documentation accordingly.

closes #73 